### PR TITLE
활동 요약 페이지에 최대 6건의 독서 활동이 표시되도록 구현

### DIFF
--- a/BookHub/src/main/java/multi/dokgi/bookhub/profile/controller/ProfileController.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/profile/controller/ProfileController.java
@@ -1,10 +1,20 @@
 package multi.dokgi.bookhub.profile.controller;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONObject;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
+
+import multi.dokgi.bookhub.config.auth.LoginUser;
+import multi.dokgi.bookhub.config.auth.dto.SessionUser;
+import multi.dokgi.bookhub.readinglog.dto.ReadingLogDTO;
+import multi.dokgi.bookhub.readinglog.service.IReadingLogService;
 
 /**
  * @author GhostFairy
@@ -13,30 +23,51 @@ import org.springframework.web.servlet.ModelAndView;
 @Controller
 public class ProfileController {
 
+	private IReadingLogService rlService;
+
+	public ProfileController(IReadingLogService rlService) {
+		this.rlService = rlService;
+	}
+
+	// 아이디 없이 프로필 페이지 접속시
+	// 로그인했으면 로그인한 회원의 프로필로 연결
 	@RequestMapping("/profile")
-	public ModelAndView profile() {
+	public ModelAndView profile(@LoginUser SessionUser user) {
 		ModelAndView mv = new ModelAndView();
 
+		if (user != null) {
+			mv.setViewName("redirect:/profile/" + user.getUserId());
+		} else {
+			mv.setViewName("redirect:/oauth2/authorization/google");
+		}
+
+		return mv;
+	}
+
+	@RequestMapping(value = { "/profile/{userId}", "/profile/{userId}/summary" })
+	public ModelAndView profileSummary(@Nullable @PathVariable("userId") String userId) {
+		ModelAndView mv = new ModelAndView();
+
+		List<ReadingLogDTO> recentLog = rlService.getRecentReadingLog(userId);
+		Map<ReadingLogDTO, JSONObject> map = new HashMap<ReadingLogDTO, JSONObject>();
+
+		for (ReadingLogDTO dto : recentLog) {
+			JSONObject book = rlService.getBookInfo(dto.getBookISBN());
+			map.put(dto, book);
+		}
+
+		mv.addObject("userId", userId);
+		mv.addObject("recentLog", map);
 		mv.setViewName("profile/summary");
 
 		return mv;
 	}
 
-	@RequestMapping(value = { "/profile/{username}", "/profile/{username}/summary" })
-	public ModelAndView profileSummary(@Nullable @PathVariable("username") String username) {
+	@RequestMapping("/profile/{userId}/library")
+	public ModelAndView profileLibrary(@Nullable @PathVariable("userId") String userId) {
 		ModelAndView mv = new ModelAndView();
 
-		mv.addObject("username", username);
-		mv.setViewName("profile/summary");
-
-		return mv;
-	}
-
-	@RequestMapping("/profile/{username}/library")
-	public ModelAndView profileLibrary(@Nullable @PathVariable("username") String username) {
-		ModelAndView mv = new ModelAndView();
-
-		mv.addObject("username", username);
+		mv.addObject("userId", userId);
 		mv.setViewName("profile/library");
 
 		return mv;

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/controller/ReadingLogController.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/controller/ReadingLogController.java
@@ -1,0 +1,52 @@
+package multi.dokgi.bookhub.readinglog.controller;
+
+import org.json.JSONObject;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+import multi.dokgi.bookhub.config.auth.LoginUser;
+import multi.dokgi.bookhub.config.auth.dto.SessionUser;
+import multi.dokgi.bookhub.readinglog.service.IReadingLogService;
+
+/**
+ * @author GhostFairy
+ *
+ */
+@Controller
+public class ReadingLogController {
+
+	private IReadingLogService rlService;
+
+	public ReadingLogController(IReadingLogService rlService) {
+		this.rlService = rlService;
+	}
+
+	@GetMapping("/readinglog/edit")
+	public ModelAndView readingLogEdit(@LoginUser SessionUser user, String isbn) {
+		ModelAndView mv = new ModelAndView();
+		JSONObject book = rlService.getBookInfo(isbn);
+
+		mv.addObject("bookInfo", book);
+		mv.addObject("userInfo", user);
+		mv.setViewName("readinglog/edit");
+
+		return mv;
+	}
+
+	@PostMapping("/readinglog/edit")
+	public ModelAndView readingLogEditResult(@LoginUser SessionUser user, String isbn, Integer startPage,
+			Integer endPage, String readDate, @Nullable String readComplete, @Nullable String summary) {
+		ModelAndView mv = new ModelAndView();
+		String userId = user.getUserId();
+
+		rlService.writeReadingLog(userId, isbn, startPage, endPage, summary, readDate, readComplete);
+
+		mv.setViewName("redirect:/readinglog/edit?isbn=" + isbn);
+
+		return mv;
+	}
+
+}

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dao/IReadingLogDAO.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dao/IReadingLogDAO.java
@@ -1,0 +1,20 @@
+package multi.dokgi.bookhub.readinglog.dao;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import multi.dokgi.bookhub.readinglog.dto.ReadingLogDTO;
+
+/**
+ * @author GhostFairy
+ *
+ */
+@Mapper
+public interface IReadingLogDAO {
+
+	public int writeReadingLog(ReadingLogDTO rlDTO);
+
+	public List<ReadingLogDTO> getRecentReadingLog(String userId);
+
+}

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dto/ReadingLogDTO.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dto/ReadingLogDTO.java
@@ -1,0 +1,31 @@
+package multi.dokgi.bookhub.readinglog.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author GhostFairy
+ *
+ */
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class ReadingLogDTO {
+
+	private int num; // 독서활동 기록번호
+	private final String userId; // 회원 ID
+	private final String bookISBN; // 책 ISBN
+	private final int startPage; // 독서 시작페이지
+	private final int endPage; // 독서 종료페이지
+	private final String summary; // 독서활동 요약
+	private final LocalDateTime readDate; // 독서활동일
+	private LocalDateTime writeDate; // 독서활동 기록일
+	private final boolean readComplete; // 완독여부
+
+}

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/IReadingLogService.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/IReadingLogService.java
@@ -1,0 +1,22 @@
+package multi.dokgi.bookhub.readinglog.service;
+
+import java.util.List;
+
+import org.json.JSONObject;
+
+import multi.dokgi.bookhub.readinglog.dto.ReadingLogDTO;
+
+/**
+ * @author GhostFairy
+ *
+ */
+public interface IReadingLogService {
+
+	public JSONObject getBookInfo(String isbn);
+
+	public int writeReadingLog(String userId, String bookISBN, int startPage, int endPage, String summary,
+			String readDate, String readComplete);
+
+	public List<ReadingLogDTO> getRecentReadingLog(String userId);
+
+}

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/ReadingLogServiceImpl.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/ReadingLogServiceImpl.java
@@ -1,0 +1,96 @@
+package multi.dokgi.bookhub.readinglog.service;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+import multi.dokgi.bookhub.readinglog.dao.IReadingLogDAO;
+import multi.dokgi.bookhub.readinglog.dto.ReadingLogDTO;
+
+/**
+ * @author GhostFairy
+ *
+ */
+@Service("ReadingLogService")
+public class ReadingLogServiceImpl implements IReadingLogService {
+
+	IReadingLogDAO rlDAO;
+
+	// 생성자 주입
+	public ReadingLogServiceImpl(IReadingLogDAO rlDAO) {
+		this.rlDAO = rlDAO;
+	}
+
+	// 인터파크 도서 API - ISBN으로 도서 정보 검색
+	@Override
+	public JSONObject getBookInfo(String isbn) {
+		String key = "CF7658C8375A9D83BC630FF2ED6A7BF592604291F66C55444E6C0402DF766DA8";
+		String result = null;
+
+		try {
+			String params = "key=" + key + "&query=" + isbn + "&queryType=isbn&output=json";
+			URL api = new URL("http://book.interpark.com/api/search.api?" + params);
+			HttpURLConnection conn = (HttpURLConnection) api.openConnection();
+			int responseCode = conn.getResponseCode();
+			if (responseCode == 200) {
+				BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+				if (br != null) {
+					StringBuffer sb = new StringBuffer();
+					String newLine = null;
+					while ((newLine = br.readLine()) != null) {
+						sb.append(newLine);
+					}
+					result = sb.toString();
+				}
+			} else {
+				System.out.println("[ReadingLogService]: 인터파크 도서 API가 오류코드를 반환함");
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		
+		if (result != null) {
+			JSONObject out = new JSONObject(((JSONArray) new JSONObject(result).get("item")).get(0).toString());
+			return out;
+		}
+
+		return null;
+	}
+
+	// 독서활동 기록하기
+	@Override
+	public int writeReadingLog(String userId, String bookISBN, int startPage, int endPage, String summary,
+			String readDate, String readComplete) {
+		// 입력된 연-월-일 문자열을 parse
+		LocalDateTime readDateParsed = LocalDate.parse(readDate).atStartOfDay();
+		// 완독여부 체크박스가 체크되지 않았으면 null이므로 false, 체크되어 null이 아니면 true
+		boolean readCompleteParsed = false;
+		if (readComplete != null) {
+			readCompleteParsed = true;
+		}
+
+		// DTO 생성
+		ReadingLogDTO rlDTO = new ReadingLogDTO(userId, bookISBN, startPage, endPage, summary, readDateParsed,
+				readCompleteParsed);
+		// DB에 입력
+		int result = rlDAO.writeReadingLog(rlDTO);
+
+		// 입력 결과 반환(1행 입력이므로 정상 결과값 1)
+		return result;
+	}
+
+	// 최근 독서활동 조회
+	@Override
+	public List<ReadingLogDTO> getRecentReadingLog(String userId) {
+		return rlDAO.getRecentReadingLog(userId);
+	}
+
+}

--- a/BookHub/src/main/resources/mybatis/mappers/readinglog-mapper.xml
+++ b/BookHub/src/main/resources/mybatis/mappers/readinglog-mapper.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+  
+<mapper namespace="multi.dokgi.bookhub.readinglog.dao.IReadingLogDAO">
+	<!-- 독서활동 기록하기 -->
+	<insert id="writeReadingLog" parameterType="ReadingLogDTO">
+		INSERT INTO
+			`bookhub`.`readinglog`(user_id, book_isbn, start_page, end_page, summary, read_date, read_complete)
+		VALUES
+			(#{userId}, #{bookISBN}, #{startPage}, #{endPage}, #{summary}, #{readDate}, #{readComplete});
+	</insert>
+	
+	<!-- 최근 독서활동 조회 -->
+	<select id="getRecentReadingLog" resultType="ReadingLogDTO">
+		SELECT
+			rl.*
+		FROM
+			`bookhub`.`readinglog` AS rl
+			JOIN
+				(SELECT
+					max(read_date) AS max_read_date,
+					max(end_page) AS max_end_date
+				FROM
+					`bookhub`.`readinglog`
+				WHERE user_id LIKE #{userId}
+				GROUP BY
+					book_ISBN) AS maxrl
+			ON (rl.read_date = maxrl.max_read_date AND rl.end_page = maxrl.max_end_date)
+		ORDER BY
+			write_date DESC
+		LIMIT
+			0, 6
+	</select>
+</mapper>

--- a/BookHub/src/main/resources/static/css/profile/profile.css
+++ b/BookHub/src/main/resources/static/css/profile/profile.css
@@ -12,13 +12,11 @@
     width: 100%;
     height: 100px;
     padding: 20px;
-    background-color: black;
 }
 #profile-username {
     float: left;
     height: 60px;
     line-height: 60px;
-    color: white;
     font-size: 32px;
     margin: 0;
 }

--- a/BookHub/src/main/resources/static/css/profile/profile.css
+++ b/BookHub/src/main/resources/static/css/profile/profile.css
@@ -10,6 +10,7 @@ body {
     box-sizing: border-box;
     width: 940px;
     margin: 0 auto;
+    margin-top: 80px;
 }
 
 #profile-head {

--- a/BookHub/src/main/resources/static/css/profile/profile.css
+++ b/BookHub/src/main/resources/static/css/profile/profile.css
@@ -1,11 +1,5 @@
 @charset "UTF-8";
 
-html,
-body {
-    margin: 0;
-    padding: 0;
-}
-
 #profile-wrapper {
     box-sizing: border-box;
     width: 940px;

--- a/BookHub/src/main/resources/static/css/profile/summary.css
+++ b/BookHub/src/main/resources/static/css/profile/summary.css
@@ -40,11 +40,42 @@
 
 .recent-item {
     float: left;
-    box-sizing: border-box;
     width: 459px;
     height: 150px;
     border-bottom: 1px solid #9b9b9b;
 }
 .recent-item:last-child {
     border: none;
+}
+.no-recent-item {
+    float:left;
+    width: 459px;
+    height: 150px;
+    line-height: 50px;
+    padding: 50px;
+    text-align: center;
+    font-weight: bold;
+}
+
+.recent-thumbnail {
+    float: left;
+    width: 130px;
+    height: 130px;
+    object-fit: contain;
+    margin: 10px;
+    border: 1px solid #9b9b9b;
+}
+.recent-title {
+    float: left;
+    width: 289px;
+    margin: 10px 10px 0 10px;
+    font-weight: bold;
+    color: royalblue;
+}
+.recent-author {
+    float: left;
+    width: 289px;
+    font-size: 14px;
+    margin: 0 10px 10px 10px;
+    color: #777777;
 }

--- a/BookHub/src/main/resources/static/css/readinglog/edit.css
+++ b/BookHub/src/main/resources/static/css/readinglog/edit.css
@@ -1,0 +1,1 @@
+@charset "UTF-8";

--- a/BookHub/src/main/resources/static/css/readinglog/readinglog.css
+++ b/BookHub/src/main/resources/static/css/readinglog/readinglog.css
@@ -10,6 +10,7 @@ body {
     box-sizing: border-box;
     width: 940px;
     margin: 0 auto;
+    margin-top: 80px;
 }
 
 #readinglog-head {

--- a/BookHub/src/main/resources/static/css/readinglog/readinglog.css
+++ b/BookHub/src/main/resources/static/css/readinglog/readinglog.css
@@ -1,0 +1,39 @@
+@charset "UTF-8";
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+}
+
+#readinglog-wrapper {
+    box-sizing: border-box;
+    width: 940px;
+    margin: 0 auto;
+}
+
+#readinglog-head {
+    box-sizing: border-box;
+    width: 100%;
+    height: 200px;
+    padding: 20px;
+    background-color: black;
+}
+
+#bookimage {
+    float: left;
+    width: 160px;
+    height: 160px;
+    object-fit: contain;
+}
+#bookTitle {
+    color: white;
+}
+#bookAuthor {
+    color: white;
+}
+
+#readinglog-body {
+    box-sizing: border-box;
+    width: 100%;
+}

--- a/BookHub/src/main/webapp/WEB-INF/views/profile/library.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/profile/library.jsp
@@ -4,7 +4,7 @@
 
     <head>
         <meta charset="UTF-8">
-        <title>${username}</title>
+        <title>${userId}</title>
         <link rel="stylesheet" href="/static/css/profile/profile.css">
         <link rel="stylesheet" href="/static/css/profile/library.css">
     </head>
@@ -17,15 +17,15 @@
             <!-- Profile Head -->
             <div id="profile-head">
                 <h1 id="profile-username">
-                    ${username}
+                    ${userId}
                 </h1>
             </div>
             <!-- Profile Tab -->
             <div id="profile-tabmenu">
-                <a class="tabmenu-btn" href="/profile/${username}">
+                <a class="tabmenu-btn" href="/profile/${userId}">
                     📋 활동 요약
                 </a>
-                <a class="tabmenu-btn activetab" href="/profile/${username}/library">
+                <a class="tabmenu-btn activetab" href="/profile/${userId}/library">
                     📚 내 서재
                 </a>
             </div>

--- a/BookHub/src/main/webapp/WEB-INF/views/profile/summary.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/profile/summary.jsp
@@ -1,10 +1,11 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
     <!DOCTYPE html>
     <html>
 
     <head>
         <meta charset="UTF-8">
-        <title>${username}</title>
+        <title>${userId}</title>
         <link rel="stylesheet" href="/static/css/profile/profile.css">
         <link rel="stylesheet" href="/static/css/profile/summary.css">
     </head>
@@ -17,15 +18,15 @@
             <!-- Profile Head -->
             <div id="profile-head">
                 <h1 id="profile-username">
-                    ${username}
+                    ${userId}
                 </h1>
             </div>
             <!-- Profile Tab -->
             <div id="profile-tabmenu">
-                <a class="tabmenu-btn activetab" href="/profile/${username}">
+                <a class="tabmenu-btn activetab" href="/profile/${userId}">
                     📋 활동 요약
                 </a>
-                <a class="tabmenu-btn" href="/profile/${username}/library">
+                <a class="tabmenu-btn" href="/profile/${userId}/library">
                     📚 내 서재
                 </a>
             </div>
@@ -41,33 +42,37 @@
                     </div>
                     <div id="calendar-stat">
                         <div class="stat-content">
-
+                        
                         </div>
                         <div class="stat-content">
-
+                        
                         </div>
                         <div class="stat-content">
-
+                        
                         </div>
                     </div>
                 </div>
                 <div id="summary-recent">
                     <div id="summary-recent-book" class="profile-section">
                         <h2 class="profile-section-title">
-                            최근에 읽은 책
+                            최근 독서 활동
                         </h2>
                         <div class="recent-content">
-                            <div class="recent-item">
-
-                            </div>
-                            <div class="recent-item">
-
-                            </div>
+                            <c:if test="${empty recentLog}">
+                                NONE
+                            </c:if>
+                            <c:if test="${!empty recentLog}">
+                                <c:forEach items="${recentLog}" var="log">
+                                    <div class="recent-item">
+                                        ${log.key.bookISBN}
+                                    </div>
+                                </c:forEach>
+                            </c:if>
                         </div>
                     </div>
                     <div id="summary-recent-review" class="profile-section">
                         <h2 class="profile-section-title">
-                            최근에 남긴 리뷰
+                            최근 리뷰
                         </h2>
                         <div class="recent-content">
                             <div class="recent-item">

--- a/BookHub/src/main/webapp/WEB-INF/views/profile/summary.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/profile/summary.jsp
@@ -59,12 +59,16 @@
                         </h2>
                         <div class="recent-content">
                             <c:if test="${empty recentLog}">
-                                NONE
+                                <div class="recent-item">    
+                                    <span class="no-recent-item">아직 독서 활동을 시작하지 않았습니다.</span>
+                                </div>
                             </c:if>
                             <c:if test="${!empty recentLog}">
                                 <c:forEach items="${recentLog}" var="log">
                                     <div class="recent-item">
-                                        ${log.key.bookISBN}
+                                        <img class="recent-thumbnail" src="${log.value.get('coverSmallUrl')}">
+                                        <a href="/readinglog/edit?isbn=${log.key.bookISBN}"><span class="recent-title" title="${log.value.get('title')}">${log.value.get('title')}</span></a>
+                                        <span class="recent-author">${log.value.get('author')}</span>
                                     </div>
                                 </c:forEach>
                             </c:if>
@@ -72,18 +76,21 @@
                     </div>
                     <div id="summary-recent-review" class="profile-section">
                         <h2 class="profile-section-title">
-                            최근 리뷰
+                            최근 작성 리뷰
                         </h2>
                         <div class="recent-content">
-                            <div class="recent-item">
-
-                            </div>
-                            <div class="recent-item">
-
-                            </div>
-                            <div class="recent-item">
-
-                            </div>
+                            <c:if test="${empty recentReview}">
+                                <div class="recent-item">    
+                                    <span class="no-recent-item">작성한 리뷰가 없습니다.</span>
+                                </div>
+                            </c:if>
+                            <c:if test="${!empty recentReview}">
+                                <c:forEach items="${recentReview}" var="review">
+                                    <div class="recent-item">
+                                        
+                                    </div>
+                                </c:forEach>
+                            </c:if>
                         </div>
                     </div>
                 </div>

--- a/BookHub/src/main/webapp/WEB-INF/views/profile/summary.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/profile/summary.jsp
@@ -55,12 +55,12 @@
                 <div id="summary-recent">
                     <div id="summary-recent-book" class="profile-section">
                         <h2 class="profile-section-title">
-                            최근 독서 활동
+                            최근 읽은 책
                         </h2>
                         <div class="recent-content">
                             <c:if test="${empty recentLog}">
                                 <div class="recent-item">    
-                                    <span class="no-recent-item">아직 독서 활동을 시작하지 않았습니다.</span>
+                                    <span class="no-recent-item">아직 독서 활동을 기록하지 않았습니다.</span>
                                 </div>
                             </c:if>
                             <c:if test="${!empty recentLog}">
@@ -76,7 +76,7 @@
                     </div>
                     <div id="summary-recent-review" class="profile-section">
                         <h2 class="profile-section-title">
-                            최근 작성 리뷰
+                            최근 작성한 리뷰
                         </h2>
                         <div class="recent-content">
                             <c:if test="${empty recentReview}">

--- a/BookHub/src/main/webapp/WEB-INF/views/readinglog/edit.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/readinglog/edit.jsp
@@ -1,0 +1,42 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+    <!DOCTYPE html>
+    <html>
+
+    <head>
+        <meta charset="UTF-8">
+        <title>${userInfo.userNick}</title>
+        <link rel="stylesheet" href="/static/css/readinglog/readinglog.css">
+        <link rel="stylesheet" href="/static/css/readinglog/edit.css">
+    </head>
+
+    <body>
+        <!-- Header -->
+
+        <!-- ReadingLog -->
+        <div id="readinglog-wrapper">
+            <!-- ReadingLog Head -->
+            <div id="readinglog-head">
+                <img id="bookimage" src="${bookInfo.get('coverLargeUrl')}">
+                <c:if test="${!empty bookInfo}">
+                    <h1 id="bookTitle">${bookInfo.get('title')}</h1>
+                    <span id="bookAuthor">${bookInfo.get('author')}</span>
+                </c:if>
+            </div>
+            <!-- ReadingLog Edit -->
+            <div id="readinglog-body">
+                <form action="/readinglog/edit" method="post">
+                    읽은 날짜: <input name="readDate" type="date" pattern="\d{4}-\d{2}-\d{2}" required><br>
+                    읽은 페이지: <input name="startPage" type="number" required> ~ <input name="endPage" type="number"
+                        required><label><input name="readComplete" value="true" type="checkbox">완독</label><br>
+                    읽는 내용 요약: <input name="summary" type="text"><input value="기록하기" type="submit">
+                    <br>(선택)
+                    <input type="hidden" name="isbn" value="${param.isbn}">
+                </form>
+            </div>
+        </div>
+
+
+    </body>
+
+    </html>


### PR DESCRIPTION
### Issue 타입(하나 이상의 Issue 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 
feat/profile_ghostfairy-> develop

### 변경 사항 <!--ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
- 독서 활동을 기록할 수 있는 페이지를 임시로 구현했습니다. 수동으로 isbn을 parameter로 넘기면 작성 페이지로 이동할 수 있습니다. (readinglog/edit?isbn=)
- 활동 요약 페이지에 최대 6건의 독서 활동이 표시되도록 구현하였습니다. 읽은 날짜(기록한 날짜 X)가 최신인 순서대로 읽어옵니다.

### 테스트 결과 <!--ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.-->
- 독서 활동 기록 페이지(임시)
![edit](https://user-images.githubusercontent.com/38088468/171773375-91b93033-ea8e-494e-9bfc-78d049f8b9e5.png)
- 최근 독서 활동
![summary](https://user-images.githubusercontent.com/38088468/171774063-fbc09127-d129-46a4-a90a-bc3d46af2cef.png)
