### PR TITLE
캘린더 접근 권한 수정 및 활동 요약 페이지 수정

### DIFF
--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/controller/ReadingLogController.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/controller/ReadingLogController.java
@@ -29,10 +29,10 @@ public class ReadingLogController {
 		ModelAndView mv = new ModelAndView();
 		JSONObject book = rlService.getBookInfo(isbn);
 
+		mv.addObject("user", user);
 		mv.addObject("bookInfo", book);
-		mv.addObject("userInfo", user);
+		
 		mv.setViewName("readinglog/edit");
-
 		return mv;
 	}
 

--- a/BookHub/src/main/resources/mybatis/mappers/readinglog-mapper.xml
+++ b/BookHub/src/main/resources/mybatis/mappers/readinglog-mapper.xml
@@ -39,6 +39,6 @@
 		ORDER BY
 			write_date DESC
 		LIMIT
-			0, 6
+			0, 3
 	</select>
 </mapper>

--- a/BookHub/src/main/resources/static/css/inc/top.css
+++ b/BookHub/src/main/resources/static/css/inc/top.css
@@ -11,8 +11,8 @@ html {
   scroll-behavior: smooth;
 }
 a, a:visited, a:hover, a:active{
-	text-decoration: none !important;
-	color: black !important;
+	text-decoration: none;
+	color: black;
 }
 ul {
   list-style: none;

--- a/BookHub/src/main/resources/static/css/profile/summary.css
+++ b/BookHub/src/main/resources/static/css/profile/summary.css
@@ -48,7 +48,7 @@
     border: none;
 }
 .no-recent-item {
-    float:left;
+    float: left;
     width: 459px;
     height: 150px;
     line-height: 50px;
@@ -65,17 +65,32 @@
     margin: 10px;
     border: 1px solid #9b9b9b;
 }
-.recent-title {
+.recent-info {
     float: left;
     width: 289px;
-    margin: 10px 10px 0 10px;
+    margin: 10px;
+}
+.recent-title {
+    display: flex;
+    max-width: 289px;
+    height: 25px;
+    line-height: 25px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-all;
+}
+.recent-title-link {
     font-weight: bold;
-    color: royalblue;
+    color: royalblue !important;
 }
 .recent-author {
-    float: left;
-    width: 289px;
+    display: flex;
+    max-width: 289px;
+    height: 20px;
+    line-height: 20px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-all;
     font-size: 14px;
-    margin: 0 10px 10px 10px;
     color: #777777;
 }

--- a/BookHub/src/main/webapp/WEB-INF/views/profile/library.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/profile/library.jsp
@@ -4,7 +4,7 @@
 
     <head>
         <meta charset="UTF-8">
-        <title>${userId}</title>
+        <title>BookHub :: 내 서재</title>
         <link rel="stylesheet" href="/static/css/profile/profile.css">
         <link rel="stylesheet" href="/static/css/profile/library.css">
     </head>
@@ -17,15 +17,15 @@
             <!-- Profile Head -->
             <div id="profile-head">
                 <h1 id="profile-username">
-                    ${userId}
+                    ${user.userNick}님의 독서 활동 캘린더
                 </h1>
             </div>
             <!-- Profile Tab -->
             <div id="profile-tabmenu">
-                <a class="tabmenu-btn" href="/profile/${userId}">
+                <a class="tabmenu-btn" href="/profile/summary">
                     📋 활동 요약
                 </a>
-                <a class="tabmenu-btn activetab" href="/profile/${userId}/library">
+                <a class="tabmenu-btn activetab" href="/profile/library">
                     📚 내 서재
                 </a>
             </div>

--- a/BookHub/src/main/webapp/WEB-INF/views/profile/summary.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/profile/summary.jsp
@@ -5,7 +5,7 @@
 
     <head>
         <meta charset="UTF-8">
-        <title>${userId}</title>
+        <title>BookHub :: 활동 요약</title>
         <link rel="stylesheet" href="/static/css/profile/profile.css">
         <link rel="stylesheet" href="/static/css/profile/summary.css">
     </head>
@@ -18,15 +18,15 @@
             <!-- Profile Head -->
             <div id="profile-head">
                 <h1 id="profile-username">
-                    ${userId}
+                    ${user.userNick}님의 독서 활동 캘린더
                 </h1>
             </div>
             <!-- Profile Tab -->
             <div id="profile-tabmenu">
-                <a class="tabmenu-btn activetab" href="/profile/${userId}">
+                <a class="tabmenu-btn activetab" href="/profile/summary">
                     📋 활동 요약
                 </a>
-                <a class="tabmenu-btn" href="/profile/${userId}/library">
+                <a class="tabmenu-btn" href="/profile/library">
                     📚 내 서재
                 </a>
             </div>
@@ -67,8 +67,10 @@
                                 <c:forEach items="${recentLog}" var="log">
                                     <div class="recent-item">
                                         <img class="recent-thumbnail" src="${bookInfo[log.bookISBN].get('coverSmallUrl')}">
-                                        <a href="/readinglog/edit?isbn=${log.bookISBN}"><span class="recent-title" title="${bookInfo[log.bookISBN].get('title')}">${bookInfo[log.bookISBN].get('title')}</span></a>
-                                        <span class="recent-author">${bookInfo[log.bookISBN].get('author')}</span>
+                                        <div class="recent-info">
+                                            <span class="recent-title" title="${bookInfo[log.bookISBN].get('title')}"><a class="recent-title-link" href="/readinglog/edit?isbn=${log.bookISBN}">${bookInfo[log.bookISBN].get('title')}</a></span>
+                                            <span class="recent-author">${bookInfo[log.bookISBN].get('author')}</span>
+                                        </div>
                                     </div>
                                 </c:forEach>
                             </c:if>

--- a/BookHub/src/main/webapp/WEB-INF/views/readinglog/edit.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/readinglog/edit.jsp
@@ -5,7 +5,7 @@
 
     <head>
         <meta charset="UTF-8">
-        <title>${userInfo.userNick}</title>
+        <title>BookHub :: 독서 활동 기록하기</title>
         <link rel="stylesheet" href="/static/css/readinglog/readinglog.css">
         <link rel="stylesheet" href="/static/css/readinglog/edit.css">
     </head>


### PR DESCRIPTION
### Issue 타입(하나 이상의 Issue 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 
feat/profile_ghostfairy-> develop

### 변경 사항 <!--ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
- 활동 요약의 최근 읽은 책 최대 표시 수를 6 → 3개로 변경
- 자신의 프로필(캘린더)에만 접근할 수 있도록 수정
- ID 대신 닉네임을 출력하도록 수정

### 테스트 결과 <!--ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.-->
- 
