### PR TITLE
누적 독서 페이지 및 연속 독서일 표시 기능 구현

### DIFF
--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/controller/ReadingLogController.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/controller/ReadingLogController.java
@@ -17,6 +17,7 @@ import multi.dokgi.bookhub.config.auth.LoginUser;
 import multi.dokgi.bookhub.config.auth.dto.SessionUser;
 import multi.dokgi.bookhub.readinglog.dto.ReadingCalendarDTO;
 import multi.dokgi.bookhub.readinglog.dto.ReadingLogDTO;
+import multi.dokgi.bookhub.readinglog.dto.ReadingStreakDTO;
 import multi.dokgi.bookhub.readinglog.service.IReadingLogService;
 
 /**
@@ -52,12 +53,17 @@ public class ReadingLogController {
 				bookInfo.put(dto.getBookISBN(), book);
 			}
 			
+			// 누적 독서 페이지
 			int accReadPages = rlService.getAccReadPages(userId);
+			
+			// 연속 독서일
+			Map<String, ReadingStreakDTO> streak = rlService.getStreak(userId);
 
 			mv.addObject("user", user);
 			mv.addObject("recentLog", recentLog);
 			mv.addObject("bookInfo", bookInfo);
 			mv.addObject("accReadPages", accReadPages);
+			mv.addObject("streak", streak);
 
 			mv.setViewName("rlog/summary");
 		} else {

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/controller/ReadingLogController.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/controller/ReadingLogController.java
@@ -40,9 +40,10 @@ public class ReadingLogController {
 
 		if (user != null) {
 			// 로그인 유저인 경우
+			String userId = user.getUserId();
 
 			// 최근 읽은 책 (최대 3개)
-			List<ReadingLogDTO> recentLog = rlService.getRecentBook(user.getUserId());
+			List<ReadingLogDTO> recentLog = rlService.getRecentBook(userId);
 
 			// 인터파크 도서 API - ISBN으로 도서 정보 검색
 			Map<String, JSONObject> bookInfo = new HashMap<String, JSONObject>();
@@ -50,10 +51,13 @@ public class ReadingLogController {
 				JSONObject book = rlService.getBookInfo(dto.getBookISBN());
 				bookInfo.put(dto.getBookISBN(), book);
 			}
+			
+			int accReadPages = rlService.getAccReadPages(userId);
 
 			mv.addObject("user", user);
 			mv.addObject("recentLog", recentLog);
 			mv.addObject("bookInfo", bookInfo);
+			mv.addObject("accReadPages", accReadPages);
 
 			mv.setViewName("rlog/summary");
 		} else {
@@ -66,8 +70,10 @@ public class ReadingLogController {
 	@RequestMapping("/rlog/recentcalendar")
 	@ResponseBody
 	public String summaryCalendar(@LoginUser SessionUser user) {
+		String userId = user.getUserId();
+		
 		// 최근 독서 활동
-		List<ReadingCalendarDTO> recentCalendar = rlService.getRecentCalendar(user.getUserId());
+		List<ReadingCalendarDTO> recentCalendar = rlService.getRecentCalendar(userId);
 		JSONObject out = new JSONObject();
 
 		out.put("recentCalendar", recentCalendar);
@@ -82,12 +88,13 @@ public class ReadingLogController {
 
 		if (user != null) {
 			// 로그인 유저인 경우
+			String userId = user.getUserId();
 
 			List<ReadingLogDTO> library = null;
 			if (q == null || q.equals("")) {
-				library = rlService.getLibrary(user.getUserId(), 1);
+				library = rlService.getLibrary(userId, 1);
 			} else {
-				library = rlService.searchLibrary(user.getUserId());
+				library = rlService.searchLibrary(userId);
 			}
 
 			// 인터파크 도서 API - ISBN으로 도서 정보 검색
@@ -140,8 +147,8 @@ public class ReadingLogController {
 
 		if (user != null) {
 			// 로그인 유저인 경우
-
 			String userId = user.getUserId();
+			
 			rlService.writeReadingLog(userId, isbn, readPage, summary, readDate, readComplete);
 
 			mv.setViewName("redirect:/rlog/edit?isbn=" + isbn);

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dao/IReadingLogDAO.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dao/IReadingLogDAO.java
@@ -19,5 +19,7 @@ public interface IReadingLogDAO {
 	public List<ReadingLogDTO> getRecentBook(String userId, int index, int limit);
 
 	public List<ReadingCalendarDTO> getRecentCalendar(String userId);
+	
+	public int getAccReadPages(String userId);
 
 }

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dao/IReadingLogDAO.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dao/IReadingLogDAO.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 
 import multi.dokgi.bookhub.readinglog.dto.ReadingCalendarDTO;
 import multi.dokgi.bookhub.readinglog.dto.ReadingLogDTO;
+import multi.dokgi.bookhub.readinglog.dto.ReadingStreakDTO;
 
 /**
  * @author GhostFairy
@@ -21,5 +22,7 @@ public interface IReadingLogDAO {
 	public List<ReadingCalendarDTO> getRecentCalendar(String userId);
 	
 	public int getAccReadPages(String userId);
+	
+	public List<ReadingStreakDTO> getStreak(String userid);
 
 }

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dto/ReadingCalendarDTO.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dto/ReadingCalendarDTO.java
@@ -2,7 +2,6 @@ package multi.dokgi.bookhub.readinglog.dto;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
@@ -11,10 +10,9 @@ import lombok.Getter;
  */
 
 @Getter
-@AllArgsConstructor
 public class ReadingCalendarDTO {
 
-	private final LocalDateTime readDate; // 독서활동일
-	private final int readPage; // 독서 페이지
+	private LocalDateTime readDate; // 독서활동일
+	private int readPage; // 독서 페이지
 
 }

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dto/ReadingStreakDTO.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/dto/ReadingStreakDTO.java
@@ -1,0 +1,19 @@
+package multi.dokgi.bookhub.readinglog.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+/**
+ * @author GhostFairy
+ *
+ */
+
+@Getter
+public class ReadingStreakDTO {
+
+	private LocalDateTime streakStartDate;
+	private LocalDateTime streakEndDate;
+	private int streakCount;
+
+}

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/IReadingLogService.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/IReadingLogService.java
@@ -1,11 +1,13 @@
 package multi.dokgi.bookhub.readinglog.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.json.JSONObject;
 
 import multi.dokgi.bookhub.readinglog.dto.ReadingCalendarDTO;
 import multi.dokgi.bookhub.readinglog.dto.ReadingLogDTO;
+import multi.dokgi.bookhub.readinglog.dto.ReadingStreakDTO;
 
 /**
  * @author GhostFairy
@@ -27,5 +29,7 @@ public interface IReadingLogService {
 	public List<ReadingLogDTO> searchLibrary(String userId);
 	
 	public int getAccReadPages(String userId);
+	
+	public Map<String, ReadingStreakDTO> getStreak(String userId);
 
 }

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/IReadingLogService.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/IReadingLogService.java
@@ -25,5 +25,7 @@ public interface IReadingLogService {
 	public List<ReadingLogDTO> getLibrary(String userId, Integer page);
 
 	public List<ReadingLogDTO> searchLibrary(String userId);
+	
+	public int getAccReadPages(String userId);
 
 }

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/ReadingLogServiceImpl.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/ReadingLogServiceImpl.java
@@ -6,7 +6,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 import multi.dokgi.bookhub.readinglog.dao.IReadingLogDAO;
 import multi.dokgi.bookhub.readinglog.dto.ReadingCalendarDTO;
 import multi.dokgi.bookhub.readinglog.dto.ReadingLogDTO;
+import multi.dokgi.bookhub.readinglog.dto.ReadingStreakDTO;
 
 /**
  * @author GhostFairy
@@ -103,6 +106,34 @@ public class ReadingLogServiceImpl implements IReadingLogService {
 	@Override
 	public int getAccReadPages(String userId) {
 		return rlDAO.getAccReadPages(userId);
+	}
+
+	// 연속 독서일 조회
+	@Override
+	public Map<String, ReadingStreakDTO> getStreak(String userId) {
+		List<ReadingStreakDTO> streak = rlDAO.getStreak(userId);
+		Map<String, ReadingStreakDTO> streakMap = new HashMap<String, ReadingStreakDTO>();
+
+		ReadingStreakDTO max = null;
+		ReadingStreakDTO current = null;
+
+		for (ReadingStreakDTO dto : streak) {
+			if (max == null) {
+				max = dto;
+			} else if (dto.getStreakCount() > max.getStreakCount()) {
+				max = dto;
+			}
+
+			if (LocalDate.now().compareTo(dto.getStreakEndDate().toLocalDate()) <= 0
+					&& LocalDate.now().compareTo(dto.getStreakStartDate().toLocalDate()) >= 0) {
+				current = dto;
+			}
+		}
+
+		streakMap.put("max", max);
+		streakMap.put("current", current);
+
+		return streakMap;
 	}
 
 	// 내 서재 조회

--- a/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/ReadingLogServiceImpl.java
+++ b/BookHub/src/main/java/multi/dokgi/bookhub/readinglog/service/ReadingLogServiceImpl.java
@@ -99,6 +99,12 @@ public class ReadingLogServiceImpl implements IReadingLogService {
 		return rlDAO.getRecentCalendar(userId);
 	}
 
+	// 누적 독서 페이지 조회
+	@Override
+	public int getAccReadPages(String userId) {
+		return rlDAO.getAccReadPages(userId);
+	}
+
 	// 내 서재 조회
 	@Override
 	public List<ReadingLogDTO> getLibrary(String userId, Integer page) {

--- a/BookHub/src/main/resources/mybatis/mappers/readinglog-mapper.xml
+++ b/BookHub/src/main/resources/mybatis/mappers/readinglog-mapper.xml
@@ -67,4 +67,24 @@
 		WHERE
 			user_id LIKE #{userId}
 	</select>
+	
+	<!-- 연속 독서 정보 조회 -->
+	<select id="getStreak" resultType="ReadingStreakDTO">
+		SELECT
+			MIN(read_date) AS streak_start_date,
+			MAX(read_date) AS streak_end_date,
+			COUNT(*) AS streak_count
+		FROM
+			(SELECT
+				read_date,
+				read_date - INTERVAL ROW_NUMBER() OVER(ORDER BY read_date) DAY AS streak_date
+			FROM
+				`bookhub`.`readinglog`
+			WHERE
+				user_id LIKE #{userId}
+			GROUP BY
+				read_date) AS streak_calc
+		GROUP BY
+			streak_date
+	</select>
 </mapper>

--- a/BookHub/src/main/resources/mybatis/mappers/readinglog-mapper.xml
+++ b/BookHub/src/main/resources/mybatis/mappers/readinglog-mapper.xml
@@ -28,8 +28,8 @@
 			JOIN
 				(SELECT
 					book_ISBN,
-					sum(read_page) as read_page,
-					max(read_date) as last_read_date
+					SUM(read_page) AS read_page,
+					MAX(read_date) AS last_read_date
 				FROM
 					`bookhub`.`readinglog`
 				WHERE
@@ -56,5 +56,15 @@
 			AND read_date BETWEEN LAST_DAY(NOW() - INTERVAL 3 MONTH) + INTERVAL 1 DAY AND NOW()
 		GROUP BY
 			read_date
+	</select>
+	
+	<!-- 누적 독서 페이지 조회 -->
+	<select id="getAccReadPages" resultType="int">
+		SELECT
+			SUM(read_page)
+		FROM
+			`bookhub`.`readinglog`
+		WHERE
+			user_id LIKE #{userId}
 	</select>
 </mapper>

--- a/BookHub/src/main/resources/static/css/home.css
+++ b/BookHub/src/main/resources/static/css/home.css
@@ -34,14 +34,17 @@
 #slide-1 {
 	color:#fff;
 	background-image:var(--slide-1-bgi);
+	background-size: cover;
 	left:0;
 }
 #slide-2 {
 	background-image:var(--slide-2-bgi);
+	background-size: cover;
 	left:100%;
 }
 #slide-3 {
 	background-image:var(--slide-3-bgi);
+	background-size: cover;
 	left:200%;
 }
 

--- a/BookHub/src/main/resources/static/css/rlog/summary.css
+++ b/BookHub/src/main/resources/static/css/rlog/summary.css
@@ -54,16 +54,24 @@
     text-align: center;
 }
 .stat-title {
-    height: 30px;
-    line-height: 30px;
+    height: 35px;
+    line-height: 35px;
     font-size: 20px;
-    font-weight: bold;
+    font-weight: normal;
 }
 .stat-value {
     display: block;
-    height: 60px;
-    line-height: 60px;
+    height: 35px;
+    line-height: 35px;
     font-size: 20px;
+    font-weight: bold;
+}
+.stat-subvalue {
+    display: block;
+    height: 20px;
+    line-height: 20px;
+    font-size: 14px;
+    color: var(--bs-gray-600);
 }
 
 #summary-recent {

--- a/BookHub/src/main/webapp/WEB-INF/views/rlog/library.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/rlog/library.jsp
@@ -19,7 +19,7 @@
         <!-- Profile Head -->
         <div id="profile-head">
             <h1 id="profile-username">
-                ${user.userNick}님의 독서 기록
+                ${user.userNick}님의 독서 기록장
             </h1>
         </div>
         <!-- Profile Tab -->
@@ -51,7 +51,7 @@
                                                     href="/rlog/edit?isbn=${book.bookISBN}">${bookInfo[book.bookISBN].get('title')}</a></div>
                                             <div class="library-author"><span>${bookInfo[book.bookISBN].get('author')}</span></div>
                                         </div>
-                                        <div class="library-summary">${book.summary}</div>
+                                        <div class="library-summary"><c:if test="${!empty book.summary}">NOTE: ${book.summary}</c:if></div>
                                         <div class="library-progress">
                                             <fmt:formatNumber value="${book.readPage/bookInfo[book.bookISBN].get('subInfo').get('itemPage')}" type="percent" var="percentReadPage"/>
                                             <fmt:parseDate value="${book.readDate}" pattern="yyyy-MM-dd'T'HH:mm" var="parsedReadDate" />

--- a/BookHub/src/main/webapp/WEB-INF/views/rlog/summary.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/rlog/summary.jsp
@@ -19,7 +19,7 @@
         <!-- Profile Head -->
         <div id="profile-head">
             <h1 id="profile-username">
-                ${user.userNick}님의 독서 기록
+                ${user.userNick}님의 독서 기록장
             </h1>
         </div>
         <!-- Profile Tab -->
@@ -82,7 +82,7 @@
                 <div id="calendar-stat">
                     <div class="stat-content">
                         <h3 class="stat-title">누적 독서 페이지</h3>
-                        <span class="stat-value"></span>
+                        <span class="stat-value"><fmt:formatNumber type="number" value="${accReadPages}" maxFractionDigits="3" /> p.</span>
                     </div>
                     <div class="stat-content">
                         <h3 class="stat-title">최대 연속 독서일</h3>

--- a/BookHub/src/main/webapp/WEB-INF/views/rlog/summary.jsp
+++ b/BookHub/src/main/webapp/WEB-INF/views/rlog/summary.jsp
@@ -82,15 +82,48 @@
                 <div id="calendar-stat">
                     <div class="stat-content">
                         <h3 class="stat-title">누적 독서 페이지</h3>
-                        <span class="stat-value"><fmt:formatNumber type="number" value="${accReadPages}" maxFractionDigits="3" /> p.</span>
+                        <span class="stat-value">
+                            <fmt:formatNumber type="number" value="${accReadPages}" maxFractionDigits="3" />
+                            p.
+                        </span>
+                        <span class="stat-subvalue">차곡차곡 쌓아온</span>
                     </div>
                     <div class="stat-content">
                         <h3 class="stat-title">최대 연속 독서일</h3>
-                        <span class="stat-value"></span>
+                        <c:choose>
+                            <c:when test="${empty streak['max'].streakCount}">
+                                <span class="stat-value">0 일</span>
+                                <span class="stat-subvalue">조금씩 꾸준히</span>
+                            </c:when>
+                            <c:otherwise>
+                                <span class="stat-value">
+                                    <fmt:formatNumber type="number" value="${streak['max'].streakCount}" maxFractionDigits="3" />
+                                    일
+                                </span>
+                                <fmt:parseDate value="${streak['max'].streakStartDate}" pattern="yyyy-MM-dd'T'HH:mm" var="parsedStreakStartDate" />
+                                <fmt:parseDate value="${streak['max'].streakEndDate}" pattern="yyyy-MM-dd'T'HH:mm" var="parsedStreakEndDate" />
+                                <span class="stat-subvalue"><fmt:formatDate pattern="yyyy년 M월 d일" value="${parsedStreakStartDate}"/> - <fmt:formatDate pattern="yyyy년 M월 d일" value="${parsedStreakEndDate}"/></span>
+                            </c:otherwise>
+                        </c:choose>
                     </div>
                     <div class="stat-content">
                         <h3 class="stat-title">현재 연속 독서일</h3>
-                        <span class="stat-value"></span>
+                            <c:choose>
+                                <c:when test="${empty streak['current'].streakCount}">
+                                    <span class="stat-value">0 일</span>
+                                    <span class="stat-subvalue">시작하기 좋은 날</span>
+                                </c:when>
+                                <c:otherwise>
+                                    <span class="stat-value">
+                                        <fmt:formatNumber type="number" value="${streak['current'].streakCount}" maxFractionDigits="3" />
+                                        일
+                                    </span>
+                                    <fmt:parseDate value="${streak['current'].streakStartDate}" pattern="yyyy-MM-dd'T'HH:mm" var="parsedStreakStartDate" />
+                                    <fmt:parseDate value="${streak['current'].streakEndDate}" pattern="yyyy-MM-dd'T'HH:mm" var="parsedStreakEndDate" />
+                                    <span class="stat-subvalue"><fmt:formatDate pattern="yyyy년 M월 d일" value="${parsedStreakStartDate}"/> - <fmt:formatDate pattern="yyyy년 M월 d일" value="${parsedStreakEndDate}"/></span>
+                                </c:otherwise>
+                            </c:choose>
+                        </span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Issue 타입(하나 이상의 Issue 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치 
feat/rlog_ghostfairy -> develop

### 변경 사항 <!--ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
- 누적 독서 페이지 표시 기능 구현
- 연속 독서일 표시 기능 구현

### 테스트 결과 <!--ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.-->
- 누적 독서 페이지 및 연속 독서일 기능
![acc_streak](https://user-images.githubusercontent.com/38088468/172542622-535c0fe3-d9ff-48d0-9b81-ee6026449cbb.png)

